### PR TITLE
Update operator related commands according to file name changes

### DIFF
--- a/src/components/snippets/k8sOperatorDeploy.js
+++ b/src/components/snippets/k8sOperatorDeploy.js
@@ -1,7 +1,7 @@
 export const k8sOpServerCode = (versionTag) => `
-kubectl create -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte_v1alpha1_ybcluster_crd.yaml
+kubectl create -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte.com_ybclusters_crd.yaml
 kubectl create -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/operator.yaml
-curl  https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte_v1alpha1_ybcluster_full_cr.yaml | sed 's/tag: 2.1.2.0-b10/tag: ${versionTag}/g' | kubectl  create -f -
+curl  https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml | sed 's/tag: .*$/tag: ${versionTag}/g' | kubectl  create -f -
 kubectl get po,sts,svc
 `
 
@@ -9,5 +9,5 @@ export const opHubServerCode = (versionTag) => `
 curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.13.0/install.sh | bash -s 0.13.0
 kubectl create -f https://operatorhub.io/install/yugabyte-operator.yaml
 kubectl create namespace yb-operator
-curl  https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte_v1alpha1_ybcluster_full_cr.yaml | sed 's/tag: 2.1.2.0-b10/tag: ${versionTag}/g' | kubectl  create -f -
+curl  https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml | sed 's/tag: .*$/tag: ${versionTag}/g' | kubectl  create -f -
 `


### PR DESCRIPTION
The following file names are changed as part of the SDK update (https://github.com/yugabyte/yugabyte-operator/pull/17), this commit updates the related documentation pages.
- yugabyte_v1alpha1_ybcluster_crd.yaml =>
  yugabyte.com_ybclusters_crd.yaml
- yugabyte_v1alpha1_ybcluster_full_cr.yaml =>
  yugabyte.com_v1alpha1_ybcluster_full_cr.yaml
- Use more generic regex to match the tag from existing file.

Ref: https://github.com/yugabyte/yugabyte-db/issues/5987