### PR TITLE
[Kubernetes] start ysqlsh from correct directory

### DIFF
--- a/src/components/snippets/kubernetesCode.js
+++ b/src/components/snippets/kubernetesCode.js
@@ -21,7 +21,7 @@ replicas.master=1,replicas.tserver=1,Image.tag=${version} --namespace yb-demo
 
 export const sqlShellCode = `
 # Make sure you have deployed the cluster using instructions above
-kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/bin/ysqlsh -- -h yb-tserver-0.yb-tservers.yb-demo
+kubectl exec -n yb-demo -it yb-tserver-0 -- sh -c "cd /home/yugabyte && ysqlsh -h yb-tserver-0.yb-tservers.yb-demo"
 `
 
 export const ysqlCode = `


### PR DESCRIPTION
-   Changes the directory to `/home/yugabyte` before starting ysqlsh in the Kubernetes pod, this makes sure the instructions like `\i share/*.sql` work as expected.
-   Ref: <https://github.com/yugabyte/charts/pull/9> (current directory is different if Helm chart is being used.)

### Scenarios Tested

-   Tried executing the modified commands to make sure they work as expected.