### PR TITLE
Update version numbers for 2.4.1 release

### DIFF
--- a/src/components/DockerInstall.vue
+++ b/src/components/DockerInstall.vue
@@ -64,7 +64,7 @@
       >
         <q-space />
         <div class="quickstart-container">
-          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#docker">Complete Docs</a>
+          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#docker">Complete Docs</a>
         </div>
       </q-tabs>
       <q-separator />
@@ -100,7 +100,7 @@
         </q-tab-panel>
       </q-tab-panels>
       <div class="quickstart-container mobile-view">
-        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#docker">Complete Docs</a>
+        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#docker">Complete Docs</a>
       </div>
     </div>
   </div>

--- a/src/components/KubernetesInstall.vue
+++ b/src/components/KubernetesInstall.vue
@@ -74,7 +74,7 @@
       >
         <q-space />
         <div class="quickstart-container">
-          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#kubernetes">Complete Docs</a>
+          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#kubernetes">Complete Docs</a>
         </div>
       </q-tabs>
       <q-separator />
@@ -110,7 +110,7 @@
         </q-tab-panel>
       </q-tab-panels>
       <div class="quickstart-container mobile-view">
-        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#kubernetes">Complete Docs</a>
+        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#kubernetes">Complete Docs</a>
       </div>
     </div>
   </div>

--- a/src/components/LinuxInstall.vue
+++ b/src/components/LinuxInstall.vue
@@ -66,7 +66,7 @@
       >
         <q-space />
         <div class="quickstart-container">
-          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#linux">Complete Docs</a>
+          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#linux">Complete Docs</a>
         </div>
       </q-tabs>
       <q-separator />
@@ -102,7 +102,7 @@
         </q-tab-panel>
       </q-tab-panels>
       <div class="quickstart-container mobile-view">
-        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#linux">Complete Docs</a>
+        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#linux">Complete Docs</a>
       </div>
     </div>
   </div>

--- a/src/components/MacInstall.vue
+++ b/src/components/MacInstall.vue
@@ -66,7 +66,7 @@
       >
         <q-space />
         <div class="quickstart-container">
-          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#macos">Complete Docs</a>
+          <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#macos">Complete Docs</a>
         </div>
       </q-tabs>
       <q-separator />
@@ -102,7 +102,7 @@
         </q-tab-panel>
       </q-tab-panels>
       <div class="quickstart-container mobile-view">
-        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore-ysql/#macos">Complete Docs</a>
+        <a target="_blank" rel="noopener" id="macos-quickstart-link" href="https://docs.yugabyte.com/latest/quick-start/explore/ysql/#macos">Complete Docs</a>
       </div>
     </div>
   </div>

--- a/src/components/snippets/macCode.js
+++ b/src/components/snippets/macCode.js
@@ -1,5 +1,5 @@
 export const dbServerCode = (version) => `
-wget https://downloads.yugabyte.com/yugabyte-${version}-darwin.tar.gz
+curl -O https://downloads.yugabyte.com/yugabyte-${version}-darwin.tar.gz
 tar xvfz yugabyte-${version}-darwin.tar.gz && cd yugabyte-${version}/
 ./bin/yugabyted start
 `

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -18,6 +18,6 @@
         "display": "v2.4 (Stable)",
         "version": "2.4.1.0",
         "versionShort": "2.4.1",
-        "appVersion": "2.4.1.0-b18"
+        "appVersion": "2.4.1.0-b20"
     }
 ]

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -15,9 +15,9 @@
     },
     {
         "name": "stable",
-        "display": "v2.2 (Stable)",
-        "version": "2.2.5.0",
-        "versionShort": "2.2.5",
-        "appVersion": "2.2.5.0-b2"
+        "display": "v2.4 (Stable)",
+        "version": "2.4.1.0",
+        "versionShort": "2.4.1",
+        "appVersion": "2.4.1.0-b18"
     }
 ]

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -11,7 +11,7 @@
         "display": "v2.4 (Stable)",
         "version": "2.4.1.0",
         "versionShort": "2.4.1",
-        "appVersion": "2.4.1.0-b27"
+        "appVersion": "2.4.1.0-b25"
     },
     {
         "name": "v2.2 (Earlier)",

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -11,13 +11,13 @@
         "display": "v2.4 (Stable)",
         "version": "2.4.1.0",
         "versionShort": "2.4.1",
-        "appVersion": "2.4.1.0-b20"
+        "appVersion": "2.4.1.0-b24"
     },
     {
-        "name": "v2.3 (Earlier)",
-        "display": "v2.3",
-        "version": "2.3.3.0",
-        "versionShort": "2.3.3",
-        "appVersion": "2.3.3.0-b106"
+        "name": "v2.2 (Earlier)",
+        "display": "v2.2",
+        "version": "2.2.6.0",
+        "versionShort": "2.2.6",
+        "appVersion": "2.2.6.0-b4"
     }
 ]

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -2,8 +2,8 @@
     {
         "name": "latest",
         "display": "v2.5 (Latest)",
-        "version": "2.5.0.0",
-        "versionShort": "2.5.0",
+        "version": "2.5.1.0",
+        "versionShort": "2.5.1",
         "appVersion": "latest"
     },
     {

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -11,7 +11,7 @@
         "display": "v2.4 (Stable)",
         "version": "2.4.1.0",
         "versionShort": "2.4.1",
-        "appVersion": "2.4.1.0-b24"
+        "appVersion": "2.4.1.0-b27"
     },
     {
         "name": "v2.2 (Earlier)",

--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -7,17 +7,17 @@
         "appVersion": "latest"
     },
     {
-        "name": "v2.3 (Earlier)",
-        "display": "v2.3",
-        "version": "2.3.3.0",
-        "versionShort": "2.3.3",
-        "appVersion": "2.3.3.0-b106"
-    },
-    {
         "name": "stable",
         "display": "v2.4 (Stable)",
         "version": "2.4.1.0",
         "versionShort": "2.4.1",
         "appVersion": "2.4.1.0-b20"
+    },
+    {
+        "name": "v2.3 (Earlier)",
+        "display": "v2.3",
+        "version": "2.3.3.0",
+        "versionShort": "2.3.3",
+        "appVersion": "2.3.3.0-b106"
     }
 ]


### PR DESCRIPTION
(Draft for now...)

* Stable version number needs an update for 2.4.1
* Latest version number needs an update for current 2.5 as well
* macOS command line should be curl rather than wget, since curl is part of a default macOS install