### PR TITLE
update version for 2.4.0

### DIFF
--- a/src/components/snippets/version.json
+++ b/src/components/snippets/version.json
@@ -2,8 +2,8 @@
     {
         "name": "latest",
         "display": "v2.5 (Latest)",
-        "version": "2.5.0.0",
-        "versionShort": "2.5.0",
+        "version": "2.5.1.0",
+        "versionShort": "2.5.1",
         "appVersion": "latest"
     },
     {
@@ -15,9 +15,9 @@
     },
     {
         "name": "stable",
-        "display": "v2.2 (Stable)",
-        "version": "2.2.5.0",
-        "versionShort": "2.2.5",
-        "appVersion": "2.2.5.0-b2"
+        "display": "v2.4 (Stable)",
+        "version": "2.4.0.0",
+        "versionShort": "2.4.0",
+        "appVersion": "2.4.0.0-b60"
     }
 ]


### PR DESCRIPTION
#26 will be the updates for 2.4.1 (and a bit more) when that ships; this is a quick update to get stable showing the right version.